### PR TITLE
Type fix

### DIFF
--- a/src/gjs.d.ts
+++ b/src/gjs.d.ts
@@ -66,5 +66,5 @@ declare interface String  {
  * Gnome class polyfills
  */
 declare module "Lang" {
-    export function Class(properties: any)
+    export function Class(properties: any): void
 }


### PR DESCRIPTION
When I was using your project I had the following typing error:

```
src/main.ts(24,34): error TS2350: Only a void function can be called with the 'new' keyword.
```

This was because of a mis-typing of `Lang.Class`. This PR fixes the behavior.